### PR TITLE
disable no-loss-of-precision rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,6 +105,7 @@ module.exports = {
     ],
     "react/jsx-fragments": ["error", "syntax"],
     "padding-line-between-statements": "off",
+    "no-loss-of-precision": "off",
     "@typescript-eslint/padding-line-between-statements": [
       "error",
       {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The LinkUp eslint configs for React project
 ## Using
 
 ```
-yarn add -D github:LinkUpStudioOld/eslint-config-react.git#v1.0.6
+yarn add -D github:LinkUpStudioOld/eslint-config-react.git
 ```
 
 - copy [.eslintrc.js](https://gist.github.com/LinkUpStudioOld/0bb6ade36a94df73b4feab12169df052) into your project

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linkup/eslint-config-next-js",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "The LinkUp eslint configs for Next.js project",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
We had duplicate rules `no-loss-of-precision` and `@typescript-eslint/no-loss-of-precision`, preferable is from the typescript-eslint.
The regular rule is disabled now.